### PR TITLE
Bugfix/update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pip install rich
-pip install recipe_scrapers
-pip install pyyaml
+rich
+recipe_scrapers
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 rich
 recipe_scrapers
 pyyaml
+platformdirs


### PR DESCRIPTION
Removes the `pip install` code from requirements.txt as that is implicitly added when running `pip install -r requirements.txt`
Also adds the [platformdirs](https://pypi.org/project/platformdirs/) package as a requirement as it not added implicitly nor explicitly and this prevented execution.